### PR TITLE
Redirect users from index.html to login/

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<script>
+			document.location.href = "login/";
+		</script>
 		<meta charset="utf-8" />
 		<title>blobs.io</title>
 		<link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
Since the "first version" of this game is no longer playable, I don't see a reason why we would need this, so I added a redirect to `~/login/`