### PR TITLE
Semi-fix: custom rooms

### DIFF
--- a/backend/Base.js
+++ b/backend/Base.js
@@ -23,7 +23,7 @@ Base.utils = { };
 Base.captchas = Base.sockets = [ ];
 Base.rooms = [
 	{
-		id: "FFA",
+		id: "ffa",
 		players: [],
 		objects: {
 			walls: []

--- a/backend/Base.js
+++ b/backend/Base.js
@@ -21,14 +21,6 @@ Base.io = Base.socket(Base.server);
 Base.sessions = require("./SessionIDManager");
 Base.utils = { };
 Base.captchas = Base.sockets = [ ];
-Base.gamemodes = {
-	ffa: {
-		players: [],
-		objects: {
-			walls: []
-		}
-	}
-};
 Base.rooms = [
 	{
 		id: "FFA",
@@ -41,10 +33,12 @@ Base.rooms = [
 
 // Add objects
 for(let i = 0; i < 50; ++i) {
-	Base.gamemodes.ffa.objects.walls.push({
-		x: Math.floor(Math.random() * 2000),
-		y: Math.floor(Math.random() * 2000)
-	});
+	for(const room of Base.rooms) {
+		room.objects.walls.push({
+			x: Math.floor(Math.random() * 2000),
+			y: Math.floor(Math.random() * 2000)
+		});
+	}
 }
 
 // Utilities

--- a/backend/Base.js
+++ b/backend/Base.js
@@ -29,6 +29,15 @@ Base.gamemodes = {
 		}
 	}
 };
+Base.rooms = [
+	{
+		id: "FFA",
+		players: [],
+		objects: {
+			walls: []
+		}
+	}
+];
 
 // Add objects
 for(let i = 0; i < 50; ++i) {

--- a/backend/api/endpoints/ffa.players.js
+++ b/backend/api/endpoints/ffa.players.js
@@ -4,7 +4,7 @@ module.exports = class Players {
 	static run(...data) {
 		const [req, res] = data;
 		res.set("status", 200);
-		res.json(Base.gamemodes.ffa.players.map(v => Object.assign(v, {id: undefined, _directionChange: undefined, img: undefined, ready: true})));
+		res.json(Base.rooms.find(v => v.id === "ffa").players.map(v => Object.assign(v, {id: undefined, _directionChange: undefined, img: undefined, ready: true})));
 	}
 	
 	static get info() {

--- a/backend/events/appCreate.js
+++ b/backend/events/appCreate.js
@@ -1,4 +1,4 @@
-const { gamemodes } = require("../Base");
+const { rooms } = require("../Base");
 class appCreateEvent {};
 /**
  * Runs the appCreate Event
@@ -46,7 +46,7 @@ appCreateEvent.run = (...args) => {
 								username: v.username,
 								lastDaily: v.lastDaily,
 								role: v.role
-							}}).concat(gamemodes.ffa.players.map(v => { return {
+							}}).concat(rooms.find(v => v.id === "ffa").players.map(v => { return {
 								location: "FFA",
 								username: v.owner,
 								br: v.br,

--- a/backend/events/disconnect.js
+++ b/backend/events/disconnect.js
@@ -8,18 +8,18 @@ class disconnectEvent {};
  */
 disconnectEvent.run = (...args) => {
     const [data, Base, io] = args;
-    if (Base.gamemodes.ffa.players.some(v => v.id === data.id)) {
-        io.sockets.emit("ffaPlayerDelete", Base.gamemodes.ffa.players.find(v => v.id === data.id).owner);
-        let user = Base.gamemodes.ffa.players.find(v => v.id === data.id);
+    if (Base.rooms.find(v => v.id === "ffa").players.some(v => v.id === data.id)) {
+        io.sockets.emit("ffaPlayerDelete", Base.rooms.find(v => v.id === "ffa").players.find(v => v.id === data.id).owner);
+        let user = Base.rooms.find(v => v.id === "ffa").players.find(v => v.id === data.id);
         if (user.guest !== true) Base.sqlite.prepare("UPDATE accounts SET distance = distance + ? WHERE username=?").then(prep => prep.run([user.distance / 1000, user.owner]));
-        Base.gamemodes.ffa.players.splice(Base.gamemodes.ffa.players.findIndex(v => v.id === data.id), 1);
+        Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].players.splice(Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.id === data.id), 1);
     }
     if (Base.sockets.find(val => val.socketid === data.id)) {
         Base.sockets[Base.sockets.findIndex(val => val.socketid === data.id)].inactiveSince = Date.now();
     }
     return {
         sockets: Base.sockets,
-        players: Base.gamemodes.ffa.players
+        players: Base.rooms.find(v => v.id === "ffa").players
     };
 };
 

--- a/backend/events/ffaCoordinateChange.js
+++ b/backend/events/ffaCoordinateChange.js
@@ -5,7 +5,7 @@ ffaCoordinateChangeEvent.run = async (...args) => {
     eventd.id = data.id;
     if (parseInt(eventd.x) === NaN || parseInt(eventd.y) === NaN || parseInt(eventd.br) === NaN) return;
     try {
-        let prev = Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === eventd.owner)];
+        let prev = Base.rooms.find(v => v.id === "ffa").players[Base.gamemodes.ffa.players.findIndex(v => v.owner === eventd.owner)];
         eventd.lastnom = prev.lastnom;
         eventd._directionChange = prev._directionChange;
         eventd.role = prev.role;
@@ -16,7 +16,7 @@ ffaCoordinateChangeEvent.run = async (...args) => {
         prev.distance += (Math.abs(prev.x - eventd.x) + Math.abs(prev.y - eventd.y));
         eventd.distance = prev.distance;
     } catch (e) {}
-    Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === eventd.owner)] = eventd;
+    Base.rooms.find(v => v.id === "ffa").players[Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.owner === eventd.owner)] = eventd;
 };
 
 module.exports = ffaCoordinateChangeEvent;

--- a/backend/events/ffaDirectionChange.js
+++ b/backend/events/ffaDirectionChange.js
@@ -2,7 +2,7 @@ class ffaDirectionChangeEvent {};
 
 ffaDirectionChangeEvent.run = (...args) => {
     const [eventd, data, io, Base] = args;
-    const target = Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === eventd.owner)];
+    const target = Base.rooms.find(v => v.id === "ffa").players[Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.owner === eventd.owner)];
     if (target === undefined) return;
     target._directionChange = Date.now();
 };

--- a/backend/events/ffaNomKey.js
+++ b/backend/events/ffaNomKey.js
@@ -78,18 +78,18 @@ function promotedTo(oldbr, newbr) {
 }
 
 ffaNomKey.run = async (data, io, Base, sqlite) => {
-    const eventd = Base.gamemodes.ffa.players.find(v => v.id === data.id);
+    const eventd = Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].players.find(v => v.id === data.id);
     if (!eventd) return;
     if (parseInt(eventd.x) === NaN || parseInt(eventd.y) === NaN || parseInt(eventd.br) === NaN) return;
 
-    for (const blobobj of Base.gamemodes.ffa.players) {
+    for (const blobobj of Base.rooms.find(v => v.id === "ffa").players) {
         if (eventd.owner !== blobobj.owner) {
             if (eventd.x < (blobobj.x + 30) && eventd.x > (blobobj.x - 30)) {
                 if (eventd.y < (blobobj.y + 30) && eventd.y > (blobobj.y - 30)) {
                     if (eventd.guest === true || blobobj.guest === true) return;
                     if (Date.now() - eventd.lastnom < 1500) return; // Nom cooldown (1.5 seconds)
                     // If blob is nommed
-                    Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.id === data.id)].lastnom = Date.now();
+                    Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].players[Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].players.findIndex(v => v.id === data.id)].lastnom = Date.now();
 
 
                     let winner = eventd;
@@ -99,13 +99,13 @@ ffaNomKey.run = async (data, io, Base, sqlite) => {
                     if (parseInt(blobobj.br) !== NaN) {
                         let result = parseInt(execSync(Base.algorith.replace(/\{ownbr\}/g, eventd.br).replace(/\{opponentbr\}/g, blobobj.br)));
                         if (result === 0) ++result;
-                        Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === winner.owner)].br = (winner.br + result > 9999 ? 9999 : winner.br + result);
-                        Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === loser.owner)].x = Math.floor(Math.random() * 150) + 150;
-                        Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === loser.owner)].y = Math.floor(Math.random() * 150) + 150;
-                        Base.gamemodes.ffa.players[Base.gamemodes.ffa.players.findIndex(v => v.owner === loser.owner)].br = (loser.br - result <= 0 ? 1 : loser.br - result);
+                        Base.rooms.find(v => v.id === "ffa").players[Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.owner === winner.owner)].br = (winner.br + result > 9999 ? 9999 : winner.br + result);
+                        Base.rooms.find(v => v.id === "ffa").players[Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.owner === loser.owner)].x = Math.floor(Math.random() * 150) + 150;
+                        Base.rooms.find(v => v.id === "ffa").players[Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.owner === loser.owner)].y = Math.floor(Math.random() * 150) + 150;
+                        Base.rooms.find(v => v.id === "ffa").players[Base.rooms.find(v => v.id === "ffa").players.findIndex(v => v.owner === loser.owner)].br = (loser.br - result <= 0 ? 1 : loser.br - result);
 
-                        loser.br = Base.gamemodes.ffa.players.find(v => v.owner === loser.owner).br;
-                        winner.br = Base.gamemodes.ffa.players.find(v => v.owner === winner.owner).br;
+                        loser.br = Base.rooms.find(v => v.id === "ffa").players.find(v => v.owner === loser.owner).br;
+                        winner.br = Base.rooms.find(v => v.id === "ffa").players.find(v => v.owner === winner.owner).br;
 
                         await sqlite.prepare("UPDATE accounts SET br=? WHERE username=?").then(v => v.run([(loser.br - result <= 0 ? 1 : loser.br - result), loser.owner]));
                         await sqlite.prepare("UPDATE accounts SET br=? WHERE username=?").then(v => v.run([(winner.br + result > 9999 ? 9999 : winner.br + result), winner.owner]));

--- a/backend/events/ffaPlayerCreate.js
+++ b/backend/events/ffaPlayerCreate.js
@@ -29,8 +29,8 @@ ffaPlayerCreateEvent.run = async (...args) => {
     nblob.role = socket.role;
     nblob.guest = socket.guest;
     nblob.distance = 0;
-    Base.gamemodes.ffa.players.push(nblob);
-    io.to(data.id).emit("ffaObjectsHeartbeat", Base.gamemodes.ffa.objects);
+    Base.rooms.find(v => v.id === "ffa").players.push(nblob);
+    io.to(data.id).emit("ffaObjectsHeartbeat", Base.rooms.find(v => v.id === "ffa").objects);
     io.to(data.id).emit("ffaHeartbeat", {
 		username: socket.username,
 		br: socket.br,

--- a/backend/server.js
+++ b/backend/server.js
@@ -65,7 +65,7 @@ setInterval(async () => {
 			username: v.username,
 			lastDaily: v.lastDaily,
 			role: v.role
-		}}).concat(Base.gamemodes.ffa.players.map(v => { return {
+		}}).concat(Base.rooms.find(v => v.id === "ffa").players.map(v => { return {
 			location: "FFA",
 			username: v.owner,
 			br: v.br,
@@ -77,8 +77,8 @@ setInterval(async () => {
 
 // Emit blob objects to all FFA players
 setInterval(() => {
-	if (Base.gamemodes.ffa.players.length === 0) return;
-    io.sockets.emit("ffaPlayerUpdate", Base.gamemodes.ffa.players);
+	if (Base.rooms.find(v => v.id === "ffa").players.length === 0) return;
+    io.sockets.emit("ffaPlayerUpdate", Base.rooms.find(v => v.id === "ffa").players);
 }, 10);
 
 io.on("connection", data => {
@@ -86,7 +86,7 @@ io.on("connection", data => {
         data.on("disconnect", () => {
             const r = require("./events/disconnect").run(data, Base, io);
             Base.sockets = r.sockets;
-            Base.gamemodes.ffa.players = r.players;
+            Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].ffa.players = r.players;
         });
         data.on("appCreate", async _ => {
             try {
@@ -128,7 +128,7 @@ io.on("connection", data => {
         data.on("ffaNomKey", () => require("./events/ffaNomKey").run(data, io, Base, sqlite));
 
         // Other events
-	data.on("requestOnlineCount", () => io.to(data.id).emit("onlineCount", Base.sockets.filter(v => v.inactiveSince === null).concat(Base.gamemodes.ffa.players).length));
+	data.on("requestOnlineCount", () => io.to(data.id).emit("onlineCount", Base.sockets.filter(v => v.inactiveSince === null).concat(Base.rooms.find(v => v.id === "ffa").players).length));
         data.on("getCaptcha", () => require("./events/getCaptcha").run(sessions, io, data, captchas).then(res => captchas = res));
         data.on("login", res => require("./events/login").run(res, io, data, sqlite, bcrypt, sessions, utils.displayError));
         data.on("register", res => require("./events/register").run(res, io, data, utils.displayError, captchas, bcrypt, sqlite));

--- a/backend/server.js
+++ b/backend/server.js
@@ -86,7 +86,7 @@ io.on("connection", data => {
         data.on("disconnect", () => {
             const r = require("./events/disconnect").run(data, Base, io);
             Base.sockets = r.sockets;
-            Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].ffa.players = r.players;
+            Base.rooms[Base.rooms.findIndex(v => v.id === "ffa")].players = r.players;
         });
         data.on("appCreate", async _ => {
             try {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "start": "node ."
   },
   "dependencies": {
-    "express": "^4.16.3",
-    "sqlite": "*",
-    "socket.io": "*",
-    "bcrypt": "*",
-    "node-fetch": "*"
+    "bcrypt": "^3.0.2",
+    "express": "^4.16.4",
+    "node-fetch": "^2.3.0",
+    "socket.io": "^2.2.0",
+    "sqlite": "^3.0.0"
   },
   "engines": {
     "node": "8.x"


### PR DESCRIPTION
This is a semi-fix for #37, which change the structure of the `Base.gamemodes` object. That property no longer exists and instead we have to use Base.rooms, which is an array of rooms. When the server restarts, there's only one room: FFA. Its ID is `ffa` (case-sensitive). Rooms can be pushed to the array, but there is no way to interact with it.
To access member properties of it we use ES6' Array function `find` and pass a callback function to it, which searches for an object in that array where its ID equals to `ffa`.
For object references in arrays you can use the [] operator and get the index with `Array.prototype.findIndex`.